### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,8 +877,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 <div align="center">
 
-[![Stargazers repo roster for @muhittincamdali/SwiftAI](https://starchart.cc/muhittincamdali/SwiftAI.svg)](https://github.com/muhittincamdali/SwiftAI/stargazers)
-
 **⭐ Star this repository if it helped you!**
 
 </div> 


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.