### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,32 @@
+# Documentation Index
+
+- [](&)Documentation/AIBestPracticesGuide.md
+- [](&)Documentation/AIManagerAPI.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/API/AIAPI.md
+- [](&)Documentation/Architecture.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ComputerVisionAPI.md
+- [](&)Documentation/ComputerVisionGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Guides/ArchitectureGuide.md
+- [](&)Documentation/Guides/PerformanceGuide.md
+- [](&)Documentation/Guides/SecurityGuide.md
+- [](&)Documentation/Guides/TestingGuide.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/MachineLearningAPI.md
+- [](&)Documentation/MachineLearningGuide.md
+- [](&)Documentation/ModelOptimizationAPI.md
+- [](&)Documentation/ModelOptimizationGuide.md
+- [](&)Documentation/NaturalLanguageProcessingAPI.md
+- [](&)Documentation/NaturalLanguageProcessingGuide.md
+- [](&)Documentation/Performance.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceOptimization.md
+- [](&)Documentation/Security.md
+- [](&)Documentation/SpeechRecognitionAPI.md
+- [](&)Documentation/SpeechRecognitionGuide.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,12 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExample/AdvancedAIExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicAIExample.swift
+- ``Examples/BasicExamples/BasicMLExample.swift
+- ``Examples/ComputerVisionExamples/ComputerVisionExample.swift
+- ``Examples/MachineLearningExamples/MachineLearningExample.swift
+- ``Examples/NaturalLanguageProcessingExamples/NLPExample.swift
+- ``Examples/QuickStartExample/QuickStartApp.swift
+- ``Examples/SpeechRecognitionExamples/SpeechRecognitionExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.